### PR TITLE
Missing return in EditStoreRefController.js getStore()

### DIFF
--- a/mvc/EditStoreRefController.js
+++ b/mvc/EditStoreRefController.js
@@ -99,7 +99,7 @@ define([
 			//		The object in the store that matches the given id.
 
 			if(this._resultsWatchHandle){ this._resultsWatchHandle.unwatch(); }
-			this.inherited(arguments);
+			return this.inherited(arguments);
 		},
 
 		commit: function(){


### PR DESCRIPTION
getStore() should return a deffered to access the model when it is loaded.
