### PR TITLE
Fixed  removeChild on GridContainer not actually removing widget when widget.dragRestriction==true 

### DIFF
--- a/layout/GridContainerLite.js
+++ b/layout/GridContainerLite.js
@@ -455,18 +455,12 @@ define([
 			if(typeof(p) == undefined || p > length){
 				p = length;
 			}
-			if(this._disabled){
+			if(this._disabled || child.dragRestriction){
 				domConstruct.place(child.domNode, zone, p);
 				domAttr.set(child.domNode, "tabIndex", "0");
 			}
 			else{
-				if(!child.dragRestriction){
-					this._dragManager.addDragItem(zone, child.domNode, p, true);
-				}
-				else{
-					domConstruct.place(child.domNode, zone, p);
-					domAttr.set(child.domNode, "tabIndex", "0");
-				}
+				this._dragManager.addDragItem(zone, child.domNode, p, true);
 			}
 			child.set("column", column);
 			return child; // Widget
@@ -474,7 +468,7 @@ define([
 
 		removeChild: function(/*Widget*/ widget){
 			//console.log("dojox.layout.GridContainerLite ::: removeChild");
-			if(this._disabled){
+			if(this._disabled || widget.dragRestriction){
 				this.inherited(arguments);
 			}
 			else{


### PR DESCRIPTION
Fixed removeChild to treat dragRestriction:true widgets as just a regular node for removal, and made the logic consistent w/ _insertChild.

Working example of the issue that this fixes:
http://jsfiddle.net/g3jCc/

Test Case: Click "Add static" then "remove first".
Expected: first item is removed
Actual: item is still present

If you click "Add Dnd" then "remove first", the gridContainer works as expected.
